### PR TITLE
Content.role enum should be optional

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for candidate in &response.candidates {
         for part in &candidate.content.parts {
             match &part.data {
-                ContentData::Text(text) => println!("{}", text),
+                ContentData::Text(text) => println!("{text}"),
                 _ => { /* Ignore other part types as we are not using tools */ }
             }
         }

--- a/examples/code_execution.rs
+++ b/examples/code_execution.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for candidate in &response.candidates {
         for part in &candidate.content.parts {
             match &part.data {
-                ContentData::Text(text) => println!("{}", text),
+                ContentData::Text(text) => println!("{text}"),
                 _ => { /* Ignore other part types as we are not using tools */ }
             }
         }

--- a/examples/custom_tool.rs
+++ b/examples/custom_tool.rs
@@ -61,10 +61,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .get("location")
                 .and_then(|v| v.as_str())
                 .unwrap_or("London, UK");
-            let weather_info = format!(
-                "The current weather in {} is sunny with a temperature of 20°C.",
-                location
-            );
+            let weather_info =
+                format!("The current weather in {location} is sunny with a temperature of 20°C.");
             Ok(serde_json::json!({
                 "weather": weather_info
             }))
@@ -89,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ContentData::FileData(_) => "File data found",
     };
 
-    println!("{}", weather);
+    println!("{weather}");
 
     Ok(())
 }

--- a/examples/generation_config.rs
+++ b/examples/generation_config.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for candidate in &response.candidates {
         for part in &candidate.content.parts {
             match &part.data {
-                ContentData::Text(text) => println!("Response: {}", text),
+                ContentData::Text(text) => println!("Response: {text}"),
                 _ => println!("Unexpected response type"),
             }
         }

--- a/examples/grounded.rs
+++ b/examples/grounded.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for candidate in &response.candidates {
         for part in &candidate.content.parts {
             match &part.data {
-                ContentData::Text(text) => println!("{}", text),
+                ContentData::Text(text) => println!("{text}"),
                 _ => { /* Ignore other part types as we are not using tools */ }
             }
         }

--- a/examples/grounded_2.rs
+++ b/examples/grounded_2.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for candidate in &response.candidates {
         for part in &candidate.content.parts {
             match &part.data {
-                ContentData::Text(text) => println!("{}", text),
+                ContentData::Text(text) => println!("{text}"),
                 _ => { /* Ignore other part types as we are not using tools */ }
             }
         }

--- a/examples/inline_data.rs
+++ b/examples/inline_data.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for candidate in &response.candidates {
         for part in &candidate.content.parts {
             match &part.data {
-                ContentData::Text(text) => println!("{}", text),
+                ContentData::Text(text) => println!("{text}"),
                 _ => { /* Ignore other part types as we are not using tools */ }
             }
         }

--- a/examples/system_instruction.rs
+++ b/examples/system_instruction.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for candidate in &response.candidates {
         for part in &candidate.content.parts {
             match &part.data {
-                ContentData::Text(text) => println!("{}", text),
+                ContentData::Text(text) => println!("{text}"),
                 _ => { /* Ignore other part types as we are not using tools */ }
             }
         }

--- a/examples/tool_param_types.rs
+++ b/examples/tool_param_types.rs
@@ -77,8 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let current_date = "2025-06-19";
     let system_message = format!(
-        "You are a helpful assistant. Today's date is {}. When scheduling meetings, use appropriate dates relative to today.",
-        current_date
+        "You are a helpful assistant. Today's date is {current_date}. When scheduling meetings, use appropriate dates relative to today."
     );
 
     let properties = HashMap::from([
@@ -208,7 +207,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 thought: false,
                 metadata: None,
             }],
-            role: Role::User,
+            role: Some(Role::User),
         }),
         contents: vec![Content {
             parts: vec![ContentPart{
@@ -216,7 +215,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 metadata: None,
                 thought: false
             }],
-            role: Role::User,
+            role: Some(Role::User),
         }],
         tools: vec![
             Tool::FunctionDeclaration(
@@ -317,8 +316,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(
         serialized_str, expected_str,
-        "Schema mismatch!\nSerialized: {}\nExpected: {}",
-        serialized_str, expected_str
+        "Schema mismatch!\nSerialized: {serialized_str}\nExpected: {expected_str}"
     );
 
     println!("\n✅ Schema verification passed!");
@@ -340,7 +338,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             FunctionHandler::Sync(Box::new(|args: &mut serde_json::Value| {
                 // Deserialize the arguments using the MeetingRequest struct
                 let meeting_request: MeetingRequest = serde_json::from_value(args.clone())
-                    .map_err(|e| format!("Failed to deserialize meeting request: {}", e))?;
+                    .map_err(|e| format!("Failed to deserialize meeting request: {e}"))?;
 
                 // Print the meeting schedule details
                 println!("📅 Meeting Details:");
@@ -371,7 +369,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 // Serialize the response back to JSON
                 serde_json::to_value(response)
-                    .map_err(|e| format!("Failed to serialize meeting response: {}", e))
+                    .map_err(|e| format!("Failed to serialize meeting response: {e}"))
             })),
         );
 
@@ -400,10 +398,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 };
 
                 println!("🤖 Model Response:");
-                println!("{}", result);
+                println!("{result}");
             }
             Err(e) => {
-                println!("❌ API call failed: {}", e);
+                println!("❌ API call failed: {e}");
             }
         }
     } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -264,11 +264,17 @@ pub enum PromptFeedback {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageMetadata {
-    prompt_token_count: u32,
-    total_token_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_token_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    total_token_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     candidates_token_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     cached_content_token_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tool_use_prompt_token_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     thoughts_token_count: Option<u32>,
     #[serde(default)]
     prompt_tokens_details: Vec<ModalityTokenCount>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,9 +7,7 @@ use serde_json::Value;
 #[serde(rename_all = "snake_case")]
 pub enum Role {
     User,
-    System,
     Model,
-    Tool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -45,7 +43,6 @@ pub enum Tool {
     },
 
     UrlContext {
-        #[serde(rename = "url_context")]
         url_context: serde_json::Value,
     },
 
@@ -103,7 +100,9 @@ pub enum FunctionCallingMode {
 #[serde(rename_all = "camelCase")]
 pub struct Content {
     pub parts: Vec<ContentPart>,
-    pub role: Role,
+    // Optional. The producer of the content. Must be either 'user' or 'model'.
+    // Useful to set for multi-turn conversations, otherwise can be left blank or unset.
+    pub role: Option<Role>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]


### PR DESCRIPTION
Hi everyone, this PR includes
- Fixing clippy warnings
- Make the `Content.role` enum to `Option<Role>` and `Role` enum now only has 2 variants: `User` and `Model`

Documentation on `Content.role`
https://ai.google.dev/api/caching#Content.FIELDS.role